### PR TITLE
Bugfix: docker failing on build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get install -y --reinstall make && \
 WORKDIR /app
 
 # Copy requirements into the container at /app
-COPY requirements.txt ./
+# Uncomment next line if you have a requirements.txt file in your hierarchy
+# COPY requirements.txt ./      
 
 # Complie Tesseract with training options (also feel free to update Tesseract versions and such!)
 RUN mkdir src && cd /app/src && \


### PR DESCRIPTION
removes requirements.txt line copy that makes Docker fail to build when no requirements.txt is found