### PR TITLE
Fix: change clone method from SSH to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Based on: https://www.youtube.com/watch?v=TpD76k2HYms
 
 ## How to use
 
-1. Clone this repo (`git clone git@github.com:artdevgame/tesseract-trainer.git`)
+1. Clone this repo (`git clone https://github.com/artdevgame/tesseract-trainer.git`)
 2. Copy your selected font into the `src/fonts` directory
 3. Configure [docker-compose.yml](./docker-compose.yml) with your preferences ([see below](#Configuration))
 4. Download and install Docker for your OS (https://www.docker.com/products/docker-desktop)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42949186/140644458-60816be4-e7ca-4f77-a21a-2b212a56cb48.png)
![image](https://user-images.githubusercontent.com/42949186/140644487-61405040-c58d-481d-8292-4189b86059e1.png)

If I don't have an SSH key, I cannot clone the repository. In addition, Github recommends using HTTPS instead of SSH.
https://docs.github.com/en/get-started/quickstart/set-up-git

But the main problem is that I cannot clone via SSH, because I get an error.
